### PR TITLE
adding correct headers in CORS reponses, plus passing test

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -10,6 +10,7 @@ Response.content_types = {
 Response.cors_headers = [
   ['Access-Control-Allow-Origin', '*'],
   ['Access-Control-Allow-Headers', 'X-Requested-With'],
+  ['Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS']
 ]
 
 function Response(content_type, content, statusCode, res, options) {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -154,7 +154,8 @@ describe('canned', function() {
       req.url = '/'
       var expectedHeaders = {
         'Access-Control-Allow-Origin': "*",
-        'Access-Control-Allow-Headers': "X-Requested-With"
+        'Access-Control-Allow-Headers': "X-Requested-With",
+        'Access-Control-Allow-Methods': "GET, POST, PUT, DELETE, OPTIONS"
       }
       res.setHeader = function(name, value) {
         if(expectedHeaders[name]) {
@@ -171,7 +172,6 @@ describe('canned', function() {
       var can2 = canned('./spec/test_responses', { cors: true, cors_headers: "Authorization" })
       req.url = '/'
       var expectedHeaders = {
-        'Access-Control-Allow-Origin': "*",
         'Access-Control-Allow-Headers': "X-Requested-With, Authorization"
       }
       res.setHeader = function(name, value) {


### PR DESCRIPTION
PUT and DELETE requests were not working with CORS. They are now.
