### PR TITLE
Log an error if content sanatization fails

### DIFF
--- a/canned.js
+++ b/canned.js
@@ -82,14 +82,15 @@ Canned.prototype._extractOptions = function (data) {
   return { statusCode: statusCode, data: lines.join('\n') }
 }
 
-function sanatize(data, cType) {
+Canned.prototype.sanatizeContent = function (data, fileObject) {
   var sanatized
-  switch (cType) {
+  switch (fileObject.mimetype) {
   case 'json':
     // make sure we return valid JSON even so we support comments
     try {
       sanatized = JSON.stringify(JSON.parse(removeJSLikeComments(data)))
     } catch (err) {
+      this._log("problem sanatizing content for " + fileObject.fname + " " + err)
       return false
     }
     break
@@ -114,7 +115,7 @@ Canned.prototype._responseForFile = function (httpObj, files, cb) {
         var _data = that._extractOptions(data)
         data = _data.data
         var statusCode = _data.statusCode
-        var content = sanatize(data, fileObject.mimetype)
+        var content = that.sanatizeContent(data, fileObject)
         if (content) {
           response = new Response(fileObject.mimetype, content, statusCode, httpObj.res, that.response_opts)
           cb(null, response)

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -11,6 +11,30 @@ describe('canned', function () {
     res = { setHeader: function () {}, end: function () {} }
   })
 
+  describe('error messages', function () {
+    var writeLog, logCan
+    beforeEach(function () {
+      var logger = {
+        write: function (msg) {
+          if (writeLog) writeLog(msg)
+        }
+      }
+      logCan = canned('./spec/test_responses', { logger: logger })
+    })
+
+    it('displays an error for unparsable json files', function (done) {
+      var regex = new RegExp('.*Syntax.*')
+      writeLog = function (message) {
+        if (regex.test(message)) {
+          expect(message).toBe("problem sanatizing content for _invalid_syntax.get.json SyntaxError: Unexpected token I")
+          done()
+        }
+      }
+      req.url = '/invalid_syntax'
+      logCan(req, res)
+    })
+  })
+
   describe('status codes', function () {
     it('sets 404 for non resolveable request', function (done) {
       req.url = '/i_do_not_exist'

--- a/spec/test_responses/_invalid_syntax.get.json
+++ b/spec/test_responses/_invalid_syntax.get.json
@@ -1,0 +1,1 @@
+I am not valid JSON!


### PR DESCRIPTION
before the error was just hidden now it is logged when he sanatization
of the content fails, this is especially important for JSON since it
needs to be parseable to be returned by canned otherwise just false is
returned

RESOLVES #4
