### PR TITLE
Bugfix/58 complex responses same file

### DIFF
--- a/canned.js
+++ b/canned.js
@@ -101,7 +101,9 @@ function getSelectedResponse(responses, content, headers) {
 
 // return multiple response bodies as array
 Canned.prototype.getEachResponse = function(data) {
-  return data.match(/(\/\/\! [\w]*:[\w\s"{}:]*)((?!\/\/\!)[\w\s{}\=\-\+|":@.,_<>\[\]/])*/g) || []
+  var matches;
+  matches = data.match(/(\/\/\! [\w]*:[\w\s"{}:]*)((?!\/\/\!)[\w\s{}\=\-\+|":@.,_<>\[\]/'\(\)\\#&^])*/g) || []
+  return matches
 }
 
 Canned.prototype.getVariableResponse = function(data, content, headers) {

--- a/example/_search.get.json
+++ b/example/_search.get.json
@@ -1,5 +1,23 @@
+// this response is the default: 
+//! params: {"search": "default"}
 {
   "search":"result",
   "key":"value"
 }
 
+//! params: {"search": "specific"}
+{
+  "search" : "specific result",
+  "key": "value"
+}
+
+//! params: {"search": "apostrophe"}
+{
+  "search":"Mary",
+  "results": [
+    {
+      "id":1,
+      "title":"There's something about Mary"
+    }
+  ]
+}

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -435,6 +435,14 @@ describe('canned', function () {
       }
       can(req, res)
     })
+    it("#58", function(done) {
+      req.url = "/multiple_get_responses?" + querystring.stringify({foo: "apostrophe"})
+      res.end = function(content) {
+        expect(content).toEqual(JSON.stringify({"response": "response with 'apostrophes'"}))
+        done()
+      }
+      can(req, res)
+    })
   })
 
   describe("variable POST responses", function() {

--- a/spec/test_responses/_multiple_get_responses.get.json
+++ b/spec/test_responses/_multiple_get_responses.get.json
@@ -7,3 +7,8 @@
 {
     "response": "response for bar"
 }
+
+//! params: {"foo": "apostrophe"}
+{
+    "response": "response with 'apostrophes'"
+}

--- a/test/bin_test.sh
+++ b/test/bin_test.sh
@@ -9,6 +9,13 @@ assert "lsof -i:8765 | grep node | awk '{print \$1}'" "node"
 
 curl -sL -w " %{http_code}" http://127.0.0.1:8765/search | grep 200
 assert  "echo $?" "0"
+
+curl -sL http://127.0.0.1:8765/search?search=specific | grep "specific result"
+assert "echo $?" "0"
+
+curl -sL http://127.0.0.1:8765/search?search=apostrophe | grep "There's something about Mary"
+assert "echo $?" "0"
+
 kill $CPID
 
 assert_end examples


### PR DESCRIPTION
(Partially) addresses issue #58 - addresses the main complaint but maybe not in the best way.

This adds a few extra characters to the regex in Canned.prototype.getEachResponse() such that responses containing apostrophes, hash marks, parentheses, ampersands, and carats are captured correctly.  

The regex in Canned.prototype.getEachResponse is brittle - a future iteration might just split where '//!' starts a line. 