### PR TITLE
Fix issue where certain characters would break files with multiple responses (#58)

### DIFF
--- a/bin/canned
+++ b/bin/canned
@@ -38,6 +38,6 @@ if (argv.q) {
   process.stdout.write('starting canned on port ' + port + ' for ' + cannedDir + '\n')
 }
 
-var can = canned.server(dir, { logger: logger, cors: cors, cors_headers: cors_headers})
+var can = canned(dir, { logger: logger, cors: cors, cors_headers: cors_headers})
 http.createServer(can).listen(port)
 

--- a/bin/canned
+++ b/bin/canned
@@ -38,6 +38,6 @@ if (argv.q) {
   process.stdout.write('starting canned on port ' + port + ' for ' + cannedDir + '\n')
 }
 
-var can = canned(dir, { logger: logger, cors: cors, cors_headers: cors_headers})
+var can = canned.server(dir, { logger: logger, cors: cors, cors_headers: cors_headers})
 http.createServer(can).listen(port)
 

--- a/canned.js
+++ b/canned.js
@@ -101,9 +101,27 @@ function getSelectedResponse(responses, content, headers) {
 
 // return multiple response bodies as array
 Canned.prototype.getEachResponse = function(data) {
-  var matches;
-  matches = data.match(/(\/\/\! [\w]*:[\w\s"{}:]*)((?!\/\/\!)[\w\s{}\=\-\+|":@.,_<>\[\]/'\(\)\\#&^])*/g) || []
-  return matches
+  var lines = data.split('\n');
+  var responses = [];
+  var current = [];
+  
+  var line;
+  current.push(lines[0]);
+  for(var i=1, len=lines.length; i<len; i++){
+    line=lines[i]
+    if (line.substring(0, 3) === '//!'){
+      responses.push( current.join('\n') )
+      current = [];
+    } 
+    current.push(line); 
+    
+  }
+  if(current.length > 0){
+    responses.push(current.join('\n'))
+  }
+
+  return responses
+
 }
 
 Canned.prototype.getVariableResponse = function(data, content, headers) {

--- a/canned.js
+++ b/canned.js
@@ -335,5 +335,5 @@ var canned = function (dir, options) {
   return c.responseFilter.bind(c)
 }
 
-module.exports = canned
+module.exports = {"server": canned, "Canned": Canned};
 

--- a/canned.js
+++ b/canned.js
@@ -294,5 +294,5 @@ var canned = function (dir, options) {
   return c.responseFilter.bind(c)
 }
 
-module.exports = {"server": canned, "Canned": Canned};
+module.exports = canned
 

--- a/canned.js
+++ b/canned.js
@@ -101,7 +101,9 @@ function getSelectedResponse(responses, content, headers) {
 
 // return multiple response bodies as array
 Canned.prototype.getEachResponse = function(data) {
-  return data.match(/(\/\/\! [\w]*:[\w\s"{}:]*)((?!\/\/\!)[\w\s{}\=\-\+|":@.,_<>\[\]/])*/g) || []
+  var matches;
+  matches = data.match(/(\/\/\! [\w]*:[\w\s"{}:]*)((?!\/\/\!)[\w\s{}\=\-\+|":@.,_<>\[\]/'\(\)\\#&^])*/g) || []
+  return matches
 }
 
 Canned.prototype.getVariableResponse = function(data, content, headers) {

--- a/canned.js
+++ b/canned.js
@@ -8,6 +8,7 @@ var Response = require('./lib/response')
 var querystring = require('querystring')
 var url = require('url')
 var cannedUtils = require('./lib/utils')
+var VariableResponseParser = require('./lib/variable-response')
 
 function Canned(dir, options) {
   this.logger = options.logger
@@ -71,71 +72,11 @@ function getContentType(mimetype){
   return Response.content_types[mimetype]
 }
 
-// replace any body comments in format //! [string]
-function stripBodyComments(data) {
-  return data && data.replace(/\/\/\! [\w]*: ([\w {}":,@./]*)/, '').trim()
-}
 
-function getSelectedResponse(responses, content, headers) {
-  var selectedResponse = responses[0]
 
-  if(!(content || headers)) return selectedResponse // noting to select on
 
-  // find request matches and assign to chosenResponse
-  responses.forEach(function(response) {
-    var regex = new RegExp(/\/\/\! [A-z]*: ([\w {}":,@.]*)/g)
-    var request = JSON.parse(regex.exec(response)[1])
-    var variation = cannedUtils.extend({}, content, headers)
 
-    if(typeof request !== 'object') return; // nothing to match on
 
-    Object.keys(request).forEach(function(key) {
-      if(request[key] === variation[key])  {
-        selectedResponse = response
-      }
-    })
-  })
-
-  return selectedResponse
-}
-
-// return multiple response bodies as array
-Canned.prototype.getEachResponse = function(data) {
-  var lines = data.split('\n');
-  var responses = [];
-  var current = [];
-  
-  var line;
-  current.push(lines[0]);
-  for(var i=1, len=lines.length; i<len; i++){
-    line=lines[i]
-    if (line.substring(0, 3) === '//!'){
-      responses.push( current.join('\n') )
-      current = [];
-    } 
-    current.push(line); 
-    
-  }
-  if(current.length > 0){
-    responses.push(current.join('\n'))
-  }
-
-  return responses
-
-}
-
-Canned.prototype.getVariableResponse = function(data, content, headers) {
-
-  // return sanatized data if no conditional body comments
-  if(!data.match(/\/\/\! [\w]*: {.*}/)) {
-    return JSON.stringify(stripBodyComments(data))
-  }
-
-  var responses = this.getEachResponse(data)
-  var selectedResponse = stripBodyComments(getSelectedResponse(responses, content, headers))
-
-  return JSON.stringify(selectedResponse)
-}
 
 Canned.prototype._extractOptions = function (data, httpObj) {
   var lines = data.split('\n')
@@ -164,7 +105,7 @@ Canned.prototype._extractOptions = function (data, httpObj) {
 
   opts.statusCode = opts.statusCode || defaultStatusCode
 
-  opts.data = JSON.parse(this.getVariableResponse(data, httpObj.content, httpObj.headers));
+  opts.data = JSON.parse(VariableResponseParser.getVariableResponse(data, httpObj.content, httpObj.headers));
 
   return opts
 }

--- a/example/_search.get.json
+++ b/example/_search.get.json
@@ -1,5 +1,23 @@
+// this response is the default: 
+//! params: {"search": "default"}
 {
   "search":"result",
   "key":"value"
 }
 
+//! params: {"search": "specific"}
+{
+  "search" : "specific result",
+  "key": "value"
+}
+
+//! params: {"search": "apostrophe"}
+{
+  "search":"Mary",
+  "results": [
+    {
+      "id":1,
+      "title":"There's something about Mary"
+    }
+  ]
+}

--- a/example/_search.get.json
+++ b/example/_search.get.json
@@ -1,4 +1,4 @@
-// this response is the default: 
+//! statusCode: 200
 //! params: {"search": "default"}
 {
   "search":"result",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,3 +22,7 @@ utils.removeJSLikeComments = function (text) {
   return text.replace(/\/\*.+?\*\/|\/\/\s.*(?=[\n\r])/g, '')
 }
 
+// replace any body comments in format //! [string]
+utils.stripBodyComments = function(data) {
+  return data && data.replace(/\/\/\! [\w]*: ([\w {}":,@./]*)/, '').trim()
+}

--- a/lib/variable-response.js
+++ b/lib/variable-response.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var cannedUtils = require('./utils')
+
+var VariableResponseParser = function(){};
+
+// return multiple response bodies as array
+VariableResponseParser.prototype.getEachResponse = function(data) {
+  var lines = data.split('\n');
+  var responses = [];
+  var current = [];
+  
+  var line;
+  current.push(lines[0]);
+  for(var i=1, len=lines.length; i<len; i++){
+    line=lines[i]
+    if (line.substring(0, 3) === '//!'){
+      responses.push( current.join('\n') )
+      current = [];
+    } 
+    current.push(line); 
+  }
+  if(current.length > 0){
+    responses.push(current.join('\n'))
+  }
+
+  return responses
+
+}
+
+VariableResponseParser.prototype.getSelectedResponse = function(responses, content, headers) {
+  var selectedResponse = responses[0]
+
+  if(!(content || headers)) return selectedResponse // noting to select on
+
+  // find request matches and assign to chosenResponse
+  responses.forEach(function(response) {
+    var regex = new RegExp(/\/\/\! [A-z]*: ([\w {}":,@.]*)/g)
+    var request = JSON.parse(regex.exec(response)[1])
+    var variation = cannedUtils.extend({}, content, headers)
+
+    if(typeof request !== 'object') return; // nothing to match on
+
+    Object.keys(request).forEach(function(key) {
+      if(request[key] === variation[key])  {
+        selectedResponse = response
+      }
+    })
+  })
+
+  return selectedResponse
+}
+
+VariableResponseParser.prototype.getVariableResponse = function(data, content, headers) {
+  // return sanatized data if no conditional body comments
+  if(!data.match(/\/\/\! [\w]*: {.*}/)) {
+    return JSON.stringify(cannedUtils.stripBodyComments(data))
+  }
+
+  var responses = this.getEachResponse(data)
+  var selectedResponse = cannedUtils.stripBodyComments(this.getSelectedResponse(responses, content, headers))
+
+  return JSON.stringify(selectedResponse)
+}
+
+module.exports = new VariableResponseParser();

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -3,14 +3,16 @@ var querystring = require("querystring")
 var canned_module = require('../canned')
 var canned = canned_module.server
 var Canned = canned_module.Canned
+var VariableResponseParser = require('../lib/variable-response')
 var path = require('path')
 var fs = require('fs')
 
-describe('Canned.prototype.getEachResponse', function(){
+
+describe('variable-response module, getEachResponse(data)', function(){
   it('splits responses on "//!"', function(done){
     var filename = './spec/test_responses/_multiple_get_responses.get.json'
     fs.readFile(filename, {encoding:'utf-8'}, function(err, data){
-      var responses = Canned.prototype.getEachResponse(data);
+      var responses = VariableResponseParser.getEachResponse(data);
       expect(responses.length).toEqual(3);
       done()
     })
@@ -19,7 +21,7 @@ describe('Canned.prototype.getEachResponse', function(){
   it('leaves the //! block on the first line', function(done){
     var filename = './spec/test_responses/_multiple_get_responses.get.json'
     fs.readFile(filename, {encoding:'utf-8'}, function(err, data){
-      var responses = Canned.prototype.getEachResponse(data);
+      var responses = VariableResponseParser.getEachResponse(data);
       for(var i=0, len=responses.length; i<len; i++){
         var lines = responses[i].split('\n')
         expect(lines[0].substr(0, 3)).toEqual('//!')

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -4,6 +4,30 @@ var canned_module = require('../canned')
 var canned = canned_module.server
 var Canned = canned_module.Canned
 var path = require('path')
+var fs = require('fs')
+
+describe('Canned.prototype.getEachResponse', function(){
+  it('splits responses on "//!"', function(done){
+    var filename = './spec/test_responses/_multiple_get_responses.get.json'
+    fs.readFile(filename, {encoding:'utf-8'}, function(err, data){
+      var responses = Canned.prototype.getEachResponse(data);
+      expect(responses.length).toEqual(3);
+      done()
+    })
+  })
+  
+  it('leaves the //! block on the first line', function(done){
+    var filename = './spec/test_responses/_multiple_get_responses.get.json'
+    fs.readFile(filename, {encoding:'utf-8'}, function(err, data){
+      var responses = Canned.prototype.getEachResponse(data);
+      for(var i=0, len=responses.length; i<len; i++){
+        var lines = responses[i].split('\n')
+        expect(lines[0].substr(0, 3)).toEqual('//!')
+      }
+      done()
+    })
+  })  
+})
 
 describe('canned', function () {
 

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -1,8 +1,6 @@
 "use strict";
 var querystring = require("querystring")
-var canned_module = require('../canned')
-var canned = canned_module.server
-var Canned = canned_module.Canned
+var canned = require('../canned')
 var VariableResponseParser = require('../lib/variable-response')
 var path = require('path')
 var fs = require('fs')

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -1,6 +1,8 @@
 "use strict";
 var querystring = require("querystring")
-var canned = require('../canned')
+var canned_module = require('../canned')
+var canned = canned_module.server
+var Canned = canned_module.Canned
 var path = require('path')
 
 describe('canned', function () {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -435,6 +435,14 @@ describe('canned', function () {
       }
       can(req, res)
     })
+    it("#58", function(done) {
+      req.url = "/multiple_get_responses?" + querystring.stringify({foo: "apostrophe"})
+      res.end = function(content) {
+        expect(content).toEqual(JSON.stringify({"response": "response with 'apostrophes'"}))
+        done()
+      }
+      can(req, res)
+    })
   })
 
   describe("variable POST responses", function() {

--- a/spec/test_responses/_multiple_get_responses.get.json
+++ b/spec/test_responses/_multiple_get_responses.get.json
@@ -7,3 +7,8 @@
 {
     "response": "response for bar"
 }
+
+//! params: {"foo": "apostrophe"}
+{
+    "response": "response with 'apostrophes'"
+}

--- a/test/bin_test.sh
+++ b/test/bin_test.sh
@@ -9,6 +9,13 @@ assert "lsof -i:8765 | grep node | awk '{print \$1}'" "node"
 
 curl -sL -w " %{http_code}" http://127.0.0.1:8765/search | grep 200
 assert  "echo $?" "0"
+
+curl -sL http://127.0.0.1:8765/search?search=specific | grep "specific result"
+assert "echo $?" "0"
+
+curl -sL http://127.0.0.1:8765/search?search=apostrophe | grep "There's something about Mary"
+assert "echo $?" "0"
+
 kill $CPID
 
 assert_end examples


### PR DESCRIPTION
Per discussion on #58 and #59, split responses in Canned.prototype.getEachResponse() by lines starting "//!" instead of using the regex to match.