### PR TITLE
Restore httpObj.fname on each attempt to get a response, because as i…

### DIFF
--- a/canned.js
+++ b/canned.js
@@ -266,12 +266,12 @@ Canned.prototype.responder = function(body, req, res) {
 
   var paths = lookup(httpObj.pathname.join('/'), that.wildcard);
   paths.splice(0,1); // The first path is the default
-
   responseHandler = function (err, resp) {
     if (err) {
       // Try more paths, if there are any still
       if (paths.length > 0) {
         httpObj.path = that.dir + paths.splice(0, 1)[0];
+        httpObj.fname = '_' + httpObj.dname;
         return that.findResponse(httpObj, responseHandler);
       } else {
         that._log(' not found\n');


### PR DESCRIPTION
…t is passed by reference it suffers modifications down the call stack