### PR TITLE
added fallback folder option for default behaviour

### DIFF
--- a/bin/canned
+++ b/bin/canned
@@ -17,6 +17,8 @@ var canned = require('../canned')
           .default('h', false)
           .alias('h', 'help')
           .describe('h', 'show the help')
+          .default('fallback', false)
+          .describe('fallback', 'fallback default folder')
           .usage('Usage: $0 [dir]')
           .argv
 
@@ -32,6 +34,7 @@ var dir = ''
 ,   logger
 ,   cannedDir
 ,   wildcard = argv.wildcard
+,   fallback = argv.fallback
 
 if (argv._.length === 1) dir = argv._[0] // use the passed directory
 if (argv.q) {
@@ -39,9 +42,10 @@ if (argv.q) {
 } else {
   logger = process.stdout
   cannedDir = path.resolve(dir)
-  process.stdout.write('starting canned on port ' + port + ' for ' + cannedDir + '\n')
+  fallbackNotice = fallback ? ", with fallback to "+path.resolve(fallback) : ""
+  process.stdout.write('starting canned on port ' + port + ' for ' + cannedDir +  fallbackNotice + '\n')
 }
 
-var can = canned(dir, { logger: logger, cors: cors, cors_headers: cors_headers, wildcard: wildcard})
+var can = canned(dir, { logger: logger, cors: cors, cors_headers: cors_headers, wildcard: wildcard, fallback: fallback } )
 http.createServer(can).listen(port)
 


### PR DESCRIPTION
This pull requests add following behaviour:
if you provide --fallback="some/path" as param to canned it will use this path as second chance.

Why its useful:
for example you are mocking API call, and have happyAllDay folder with all successful responses, but you need to implement some feature, that is not in main scenario.
So you need to copy all the responses and change one you need.

Using this feature you can just create one more folder and put there only one(or some) specific file and point fallback to happyAllDay folder.
So your specific folder will be provided first and everything absent there will be provided by happy all day.

