### PR TITLE
Headers config (programmatic)

### DIFF
--- a/canned.js
+++ b/canned.js
@@ -15,7 +15,8 @@ function Canned(dir, options) {
   this.wildcard = options.wildcard || 'any'
   this.response_opts = {
     cors_enabled: options.cors,
-    cors_headers: options.cors_headers
+    cors_headers: options.cors_headers,
+    configured_headers: options.headers
   }
   this.dir = process.cwd() + '/' + dir
 }

--- a/lib/response.js
+++ b/lib/response.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 function Response(content_type, content, statusCode, res, options, custom_headers) {
   this.cors_enabled = !!options.cors_enabled
   this.cors_headers = options.cors_headers
+  this.configured_headers = options.configured_headers || []
   this.content_type = content_type
   this.content = content
   this.statusCode = statusCode
@@ -37,6 +38,7 @@ Response.prototype.headers = function () {
   headers = this._addContentTypeHeaders(headers)
   headers = this._addCORSHeaders(headers)
   headers = this._addCustomHeaders(headers)
+  headers = this._addConfiguredHeaders(headers)
   return Object.keys(headers).map(function(key){
     return [key, headers[key]]
   })
@@ -65,9 +67,17 @@ Response.prototype._addCORSHeaders = function (headers) {
 }
 
 Response.prototype._addCustomHeaders = function (headers) {
-  this.custom_headers.forEach(function(header) {
+  this.custom_headers.forEach(function (header) {
     var key = Object.keys(header)[0]
     headers[key] = header[key]
+  })
+  return headers
+}
+
+Response.prototype._addConfiguredHeaders = function (headers) {
+  var configured_headers = this.configured_headers
+  Object.keys(configured_headers).forEach(function (key) {
+    headers[key] = configured_headers[key]
   })
   return headers
 }

--- a/lib/response.js
+++ b/lib/response.js
@@ -33,16 +33,19 @@ Response.prototype.send = function () {
 }
 
 Response.prototype.headers = function () {
-  var headers = []
+  var headers = {}
   headers = this._addContentTypeHeaders(headers)
   headers = this._addCORSHeaders(headers)
   headers = this._addCustomHeaders(headers)
-  return headers
+  return Object.keys(headers).map(function(key){
+    return [key, headers[key]]
+  })
+
 }
 
 Response.prototype._addContentTypeHeaders = function (headers) {
   if (this.content_type) {
-    headers.push(['Content-Type', this.content_type])
+    headers['Content-Type'] = this.content_type
   }
   return headers
 }
@@ -51,10 +54,11 @@ Response.prototype._addCORSHeaders = function (headers) {
   var that = this;
   if (this.cors_enabled) {
     Response.cors_headers.forEach(function (h) {
+      var key = h[0]
       if (!!that.cors_headers && h[0] === 'Access-Control-Allow-Headers')
-        headers.push([h[0], h[1] + ", " + that.cors_headers])
+        headers[key] = h[1] + ", " + that.cors_headers
       else
-        headers.push(h)
+        headers[key] = h[1]
     })
   }
   return headers
@@ -63,7 +67,7 @@ Response.prototype._addCORSHeaders = function (headers) {
 Response.prototype._addCustomHeaders = function (headers) {
   this.custom_headers.forEach(function(header) {
     var key = Object.keys(header)[0]
-    headers.push([key, header[key]])
+    headers[key] = header[key]
   })
   return headers
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canned",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "serve canned responses to mock an api, based on files in a folder",
   "main": "canned.js",
   "scripts": {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -293,7 +293,7 @@ describe('canned', function () {
       can(req, res)
     })
 
-    it('adds custom headers', function (done) {
+    it('adds custom CORS headers', function (done) {
       var can2 = canned('./spec/test_responses', { cors: true, cors_headers: "Authorization" })
       req.url = '/'
       var expectedHeaders = {
@@ -309,6 +309,25 @@ describe('canned', function () {
       }
       can2(req, res)
     })
+  })
+
+  it('adds custom configured headers', function (done) {
+    var can2 = canned('./spec/test_responses', { headers: {
+      'Content-Type': 'application/my-custom-type+json; charset=UTF8'
+    }})
+    req.url = '/empty'
+    var expectedHeaders = {
+      'Content-Type': 'application/my-custom-type+json; charset=UTF8'
+    }
+    res.setHeader = function (name, value) {
+      if (expectedHeaders[name]) {
+        expect(expectedHeaders[name]).toBe(value)
+        delete expectedHeaders[name]
+      }
+      // all expected headers have been set!
+      if (Object.keys(expectedHeaders).length === 0) done()
+    }
+    can2(req, res)
   })
 
   describe('variable GET responses', function () {


### PR DESCRIPTION
Add custom headers (not just CORS) when using canned programmatically.

Note that any given headers are overriding whatever canned figured out internally (e.g. ‘Content-Type), my use case for that is serving a custom “JSON dialect” without adding the config via comments to every single file.

Did a slight refactoring of the internal handling to make that easier.

Not added to CLI options because not sure about naming.
