### PR TITLE
get responses with multiple parameters correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Contributors
 * [kevinschumacher](https://github.com/kevinschumacher)
 * [msurdi](https://github.com/msurdi)
 * [Brendan Rius](https://github.com/brendan-rius)
+* [Rocco Russo](https://github.com/xdemocle)
 
 License
 -------

--- a/canned.js
+++ b/canned.js
@@ -9,6 +9,7 @@ var querystring = require('querystring')
 var url = require('url')
 var cannedUtils = require('./lib/utils')
 var lookup = require('./lib/lookup')
+var _ = require('lodash')
 
 function Canned(dir, options) {
   this.logger = options.logger
@@ -87,6 +88,13 @@ Canned.prototype.parseMetaData = function(response) {
       var matchedRequest = requestMatch.exec(line)
       if(matchedRequest) {
         metaData.request = JSON.parse(matchedRequest[1])
+
+        // Force all requests values to be a string.
+        // Otherwise comparison in getSelectedResponse doesn't works
+        _.each(metaData.request, function(value, key){
+          metaData.request[key] = String(value)
+        })
+
         return
       }
       var matchedOptions = optionsMatch.exec(line)
@@ -129,7 +137,7 @@ Canned.prototype.getSelectedResponse = function(responses, content, headers) {
     if(typeof metaData.request !== 'object') return; // nothing to match on
 
     Object.keys(metaData.request).forEach(function(key) {
-      if(metaData.request[key] === variation[key])  {
+      if(_.isMatch(variation, metaData.request)) {
         selectedResponse.data = cannedUtils.removeSpecialComments(response)
         if(metaData.statusCode) selectedResponse.statusCode = metaData.statusCode
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/sideshowcoder/canned"
   },
   "dependencies": {
+    "lodash": "^3.10.1",
     "optimist": "^0.6.0"
   },
   "devDependencies": {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -453,10 +453,20 @@ describe('canned', function () {
       }
       can(req, res)
     })
+
     it("#58", function(done) {
       req.url = "/multiple_get_responses?" + querystring.stringify({foo: "apostrophe"})
       res.end = function(content) {
         expect(content).toEqual(JSON.stringify({"response": "response with 'apostrophes'"}))
+        done()
+      }
+      can(req, res)
+    })
+
+    it("#73", function (done) {
+      req.url = "/multiple_get_responses?" + querystring.stringify({"foo": "bar", "index": 1})
+      res.end = function (content) {
+        expect(content).toEqual(JSON.stringify({"response": "response with index 1"}))
         done()
       }
       can(req, res)

--- a/spec/test_responses/_multiple_get_responses.get.json
+++ b/spec/test_responses/_multiple_get_responses.get.json
@@ -12,3 +12,8 @@
 {
     "response": "response with 'apostrophes'"
 }
+
+//! params: {"foo": "bar", "index": 1}
+{
+    "response": "response with index 1"
+}


### PR DESCRIPTION
Currently get responses with multiple parameters are not handled
correctly. This tests shows this, according with #73