### PR TITLE
Fix 3 simple bugs

### DIFF
--- a/canned.js
+++ b/canned.js
@@ -97,6 +97,14 @@ function stringifyValues(object) {
   })
 }
 
+function isContentTypeJson(request) {
+  var isJson = false;
+  if (request.headers && request.headers['content-type']) {
+    isJson = request.headers['content-type'].indexOf('application/json') !== -1;
+  }
+  return isJson;
+}
+
 
 Canned.prototype.parseMetaData = function(response) {
   var metaData = {}
@@ -361,8 +369,7 @@ Canned.prototype.responseFilter = function (req, res) {
     })
     req.on('end', function () {
       var responderBody = querystring.parse(body);
-      if (req.headers && req.headers['content-type'] && 
-                    req.headers['content-type'].indexOf('application/json') !== -1) {
+      if (isContentTypeJson(req)) {
         try {
           responderBody = JSON.parse(body)
         } catch (e) {

--- a/canned.js
+++ b/canned.js
@@ -87,10 +87,10 @@ function getContentType(mimetype){
   return Response.content_types[mimetype]
 }
 
-function traverseAndSanitise(object) {
+function traverseAndSanitize(object) {
   _.each(object, function(value, key) {
     if (typeof value === "object") {
-      traverseAndSanitise(value);
+      traverseAndSanitize(value);
     } else {
       object[key] = String(value)
     }
@@ -114,7 +114,7 @@ Canned.prototype.parseMetaData = function(response) {
 
         // Force all requests values to be a string.
         // Otherwise comparison in getSelectedResponse doesn't works
-        traverseAndSanitise(metaData.request);
+        traverseAndSanitize(metaData.request);
         return
       }
       var matchedOptions = optionsMatch.exec(line)
@@ -150,7 +150,7 @@ Canned.prototype.getSelectedResponse = function(responses, content, headers) {
     customHeaders: metaData.customHeaders
   }
 
-  traverseAndSanitise(content);
+  traverseAndSanitize(content);
 
   responses.forEach(function(response) {
     var metaData = that.parseMetaData(response)

--- a/canned.js
+++ b/canned.js
@@ -87,10 +87,10 @@ function getContentType(mimetype){
   return Response.content_types[mimetype]
 }
 
-function traverseAndSanitize(object) {
+function stringifyValues(object) {
   _.each(object, function(value, key) {
     if (typeof value === "object") {
-      traverseAndSanitize(value);
+      stringifyValues(value);
     } else {
       object[key] = String(value)
     }
@@ -111,10 +111,7 @@ Canned.prototype.parseMetaData = function(response) {
       var matchedRequest = requestMatch.exec(line)
       if(matchedRequest) {
         metaData.request = JSON.parse(matchedRequest[1])
-
-        // Force all requests values to be a string.
-        // Otherwise comparison in getSelectedResponse doesn't works
-        traverseAndSanitize(metaData.request);
+        stringifyValues(metaData.request);
         return
       }
       var matchedOptions = optionsMatch.exec(line)
@@ -150,7 +147,7 @@ Canned.prototype.getSelectedResponse = function(responses, content, headers) {
     customHeaders: metaData.customHeaders
   }
 
-  traverseAndSanitize(content);
+  stringifyValues(content);
 
   responses.forEach(function(response) {
     var metaData = that.parseMetaData(response)

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -584,6 +584,28 @@ describe('canned', function () {
       can(req, res)
     })
 
+    it('should return the first response JSON body on payload match even if content type has charset', function (done) {
+      data = '{"email":"one@example.com"}'
+      req.url = '/multiple_responses'
+      req.headers['content-type'] = 'application/json; charset=UTF-8'
+      res.end = function (content) {
+        expect(content).toEqual(JSON.stringify({"response": "response for one@example.com"}))
+        done()
+      }
+      can(req, res)
+    })
+
+    it('should handle request bodies containing arrays', function (done) {
+      data = '{"email": "two@example.com","topics": [1,2]}'
+      req.url = '/multiple_responses'
+      req.headers['content-type'] = 'application/json; charset=UTF-8'
+      res.end = function (content) {
+        expect(content).toEqual(JSON.stringify({"response": "response for two@example.com topics 1,2"}))
+        done()
+      }
+      can(req, res)
+    })
+
     it('should return the first response JSON body on payload match (because JSON body is invalid)', function (done) {
       data = 'bad json data'
       req.url = '/multiple_responses'

--- a/spec/test_responses/_multiple_responses.post.json
+++ b/spec/test_responses/_multiple_responses.post.json
@@ -7,3 +7,8 @@
 {
     "response": "response for two@example.com"
 }
+
+//! body: {"email": "two@example.com", "topics": ["1","2"]}
+{
+    "response": "response for two@example.com topics 1,2"
+}


### PR DESCRIPTION
- The regex for matching request, was not considering arrays in the
request JSON
- For request with a request body, canned was checking content type to
exactly match `application/json`, which is not good as browsers may
sent charset as well with the content type.
- For matching request and filters with more accuracy, we were
converting the values of all keys in request to string before
comparing, but this was being done wrong as it was creating string of
Objects and arrays as well, which it shouldn’t