### PR TITLE
Allow forward slashes in json content for body, params and header annotations

### DIFF
--- a/lib/canned.js
+++ b/lib/canned.js
@@ -113,7 +113,7 @@ Canned.prototype.parseMetaData = function(response) {
   var that = this
 
   var optionsMatch = new RegExp(/\/\/!.*[statusCode|contentType|customHeaders]/g)
-  var requestMatch = new RegExp(/\/\/! [body|params|header]+: ([\w {}":\[\]\-\+\%,@.]*)/g)
+  var requestMatch = new RegExp(/\/\/! [body|params|header]+: ([\w {}":\[\]\-\+\%,@.\/]*)/g)
 
   lines.forEach(function(line) {
     if(line.indexOf("//!") === 0) { // special comment line

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -623,6 +623,17 @@ describe('canned', function () {
       can(req, res)
     })
 
+    it('should handle request bodies containing urls', function (done) {
+      data = '{"url": "http://example.com"}'
+      req.url = '/response_with_url_param'
+      req.headers['content-type'] = 'application/json'
+      res.end = function (content) {
+        expect(content).toEqual(JSON.stringify({"response": "response for url in param"}))
+        done()
+      }
+      can(req, res)
+    })
+
     it('should return the first response JSON body on payload match (because JSON body is invalid)', function (done) {
       data = 'bad json data'
       req.url = '/multiple_responses'

--- a/spec/test_responses/_response_with_url_param.post.json
+++ b/spec/test_responses/_response_with_url_param.post.json
@@ -1,0 +1,5 @@
+//! body: {"url":"http://example.com"}
+{
+    "response": "response for url in param"
+}
+


### PR DESCRIPTION
Hi,

I needed to be able to test against URLs provided in the comment lines, I added a test for allowing forward slashes in the JSON to be parsed.

Before: unexpected end of input / crash
After: correctly parsed request metadata

Cheers