### PR TITLE
Clarify how cors_headers works and accept as an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ There are 2 ways here, either you embed it somewhere programmatically
 
     var canned = require('canned')
     ,   http = require('http')
-    ,   opts = { cors: true, logger: process.stdout }
+    ,   opts = { logger: process.stdout }
 
     can = canned('/path/to/canned/response/folder', opts)
 
@@ -258,6 +258,17 @@ Also if you need additional headers to be served alongside the CORS headers
 these can be added like this (thanks to runemadsen)
 
     $ canned --headers "Authorization, Another-Header"
+
+To enable CORS programatically, you can use the following options:
+
+    var canned = require('canned')
+    ,   http = require('http')
+    ,   opts = { 
+            cors: true, 
+            cors_headers: ["Content-Type", "Location"]
+        }
+
+Optionally, the cors_headers value can be a comma-separated string, as per the CLI option.
 
 For more information checkout [the pull request](https://github.com/sideshowcoder/canned/pull/9)
 

--- a/lib/canned.js
+++ b/lib/canned.js
@@ -13,9 +13,13 @@ var _ = require('lodash')
 function Canned(dir, options) {
   this.logger = options.logger
   this.wildcard = options.wildcard || 'any'
+  var cors_headers = options.cors_headers
+  if (cors_headers && cors_headers.join) {
+    cors_headers = cors_headers.join(', ')
+  }
   this.response_opts = {
     cors_enabled: options.cors,
-    cors_headers: options.cors_headers
+    cors_headers: cors_headers
   }
   this.dir = process.cwd() + '/' + dir
 }

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -351,11 +351,28 @@ describe('canned', function () {
       can(req, res)
     })
 
-    it('adds custom headers', function (done) {
-      var can2 = canned('./spec/test_responses', { cors: true, cors_headers: "Authorization" })
+    it('adds custom headers from a string', function (done) {
+      var can2 = canned('./spec/test_responses', { cors: true, cors_headers: "Authorization, Content-Type" })
       req.url = '/'
       var expectedHeaders = {
-        'Access-Control-Allow-Headers': "X-Requested-With, Authorization"
+        'Access-Control-Allow-Headers': "X-Requested-With, Authorization, Content-Type"
+      }
+      res.setHeader = function (name, value) {
+        if (expectedHeaders[name]) {
+          expect(expectedHeaders[name]).toBe(value)
+          delete expectedHeaders[name]
+        }
+        // all expected headers have been set!
+        if (Object.keys(expectedHeaders).length === 0) done()
+      }
+      can2(req, res)
+    })
+
+    it('adds custom headers from an array', function (done) {
+      var can2 = canned('./spec/test_responses', { cors: true, cors_headers: ["Authorization", "Content-Type"] })
+      req.url = '/'
+      var expectedHeaders = {
+        'Access-Control-Allow-Headers': "X-Requested-With, Authorization, Content-Type"
       }
       res.setHeader = function (name, value) {
         if (expectedHeaders[name]) {


### PR DESCRIPTION
I've updated the README a bit, it wasn't clear how to use the cors_headers config option.

I've also made it accept an array or a string to reduce pain on the caller a little.

Cheers