### PR TITLE
Fix up regex, fails test for #79(!)

### DIFF
--- a/lib/canned.js
+++ b/lib/canned.js
@@ -116,8 +116,8 @@ Canned.prototype.parseMetaData = function(response) {
   var lines = response.split("\n")
   var that = this
 
-  var optionsMatch = new RegExp(/\/\/!.*[statusCode|contentType|customHeaders]/g)
-  var requestMatch = new RegExp(/\/\/! [body|params|header]+: ([\w {}":\[\]\-\+\%,@.\/]*)/g)
+  var optionsMatch = new RegExp(/\/\/!.*(?:statusCode|contentType|customHeaders)/)
+  var requestMatch = new RegExp(/\/\/!.*(?:body|params|header):\s+([\w {}":\[\]\-\+\%,@.\/]*)/)
 
   lines.forEach(function(line) {
     if(line.indexOf("//!") === 0) { // special comment line

--- a/lib/canned.js
+++ b/lib/canned.js
@@ -108,41 +108,52 @@ function isContentTypeJson(request) {
   return isJson;
 }
 
+/**
+ * _parseOptions takes a single line from a file and extracts
+ * JSON data if possible. Returns an object.
+ */
+Canned.prototype._parseOptions = function(line) {
+  try {
+    line = line.replace("//!", '')
+    var content = line.split(',').map(function (s) {
+      var parts = s.split(':');
+      parts[0] = '"' + parts[0].trim() + '"'
+      return parts.join(':')
+    }).join(',')
+
+    return JSON.parse('{' + content  + '}')
+  } catch(e) {
+    that._log('Invalid file header format try //! statusCode: 201')
+    return {};
+  }
+}
 
 Canned.prototype.parseMetaData = function(response) {
-  var metaData = {}
+  var metaData = {},
+      lines,
+      that = this,
+      optionsMatch = new RegExp(/\/\/!.*(?:statusCode|contentType|customHeaders)/),
+      requestMatch = new RegExp(/\/\/!.*(?:body|params|header):\s+([\w {}":\[\]\-\+\%,@.\/]*)/)
+
   // convert CR+LF => LF+LF, CR => LF, fixes line breaks causing issues in windows
   response = response.replace("\r", "\n");
-  var lines = response.split("\n")
-  var that = this
 
-  var optionsMatch = new RegExp(/\/\/!.*(?:statusCode|contentType|customHeaders)/)
-  var requestMatch = new RegExp(/\/\/!.*(?:body|params|header):\s+([\w {}":\[\]\-\+\%,@.\/]*)/)
+  // we only care about special comment lines
+  lines = response.split("\n").filter(function(line) {
+    return line.indexOf("//!") === 0;
+  })
 
   lines.forEach(function(line) {
-    if(line.indexOf("//!") === 0) { // special comment line
-      var matchedRequest = requestMatch.exec(line)
-      if(matchedRequest) {
-        metaData.request = JSON.parse(matchedRequest[1])
-        stringifyValues(metaData.request);
-        return
-      }
-      var matchedOptions = optionsMatch.exec(line)
-      if(matchedOptions) {
-        try {
-          line = line.replace("//!", '')
-          var content = line.split(',').map(function (s) {
-            var parts = s.split(':');
-            parts[0] = '"' + parts[0].trim() + '"'
-            return parts.join(':')
-          }).join(',')
-          var opts = JSON.parse('{' + content  + '}')
-          cannedUtils.extend(metaData, opts)
-        } catch(e) {
-          that._log('Invalid file header format try //! statusCode: 201')
-        }
-        return
-      }
+    var matchedRequest = requestMatch.exec(line)
+    if (matchedRequest) {
+      metaData.request = JSON.parse(matchedRequest[1])
+      stringifyValues(metaData.request);
+      return
+    }
+
+    var matchedOptions = optionsMatch.exec(line)
+    if (matchedOptions) {
+      cannedUtils.extend(metaData, that._parseOptions(line))
     }
   })
 
@@ -314,7 +325,7 @@ Canned.prototype.responder = function(body, req, res) {
       }
     }
   }
-  
+
   var paths = lookup(httpObj.pathname.join('/'), that.wildcard);
   paths.splice(0,1); // The first path is the default
   responseHandler = function (err, resp) {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -565,6 +565,97 @@ describe('canned', function () {
     })
   })
 
+  describe("parsing metadata", function() {
+    it("Should accept statusCode", function(done) {
+      var Canned = require('../lib/canned')
+      var can = new Canned('./spec/test_responses', {});
+      var mock_text = '//! statusCode: 418';
+      var parsedMeta = can.parseMetaData(mock_text);
+
+      expect(parsedMeta).toEqual({
+        statusCode: 418
+      });
+      done();
+    })
+
+    it("Should accept customHeaders", function(done) {
+      var Canned = require('../lib/canned')
+      var can = new Canned('./spec/test_responses', {});
+      var mock_text = '//! statusCode: 418\n' +
+                      '//! customHeaders: {"Authorization": "Bearer xyz"}';
+      var parsedMeta = can.parseMetaData(mock_text);
+
+      expect(parsedMeta).toEqual({
+        statusCode: 418,
+        customHeaders: {
+          Authorization: 'Bearer xyz'
+        }
+      });
+      done();
+    })
+
+    it("Should accept request body", function(done) {
+      var Canned = require('../lib/canned')
+      var can = new Canned('./spec/test_responses', {});
+      var mock_text = '//! statusCode: 418\n' +
+                      '//! customHeaders: {"Authorization": "Bearer xyz"}\n' +
+                      '//! body: {"colour": "green"}';
+      var parsedMeta = can.parseMetaData(mock_text);
+
+      expect(parsedMeta).toEqual({
+        statusCode: 418,
+        customHeaders: {
+          Authorization: 'Bearer xyz'
+        },
+        request: {
+          colour: 'green'
+        }
+      });
+      done();
+    })
+
+    it("Should accept request body", function(done) {
+      var Canned = require('../lib/canned')
+      var can = new Canned('./spec/test_responses', {});
+      var mock_text = '//! statusCode: 418\n' +
+                      '//! customHeaders: {"Authorization": "Bearer xyz"}\n' +
+                      '//! body: {"colour": "green"}';
+      var parsedMeta = can.parseMetaData(mock_text);
+
+      expect(parsedMeta).toEqual({
+        statusCode: 418,
+        customHeaders: {
+          Authorization: 'Bearer xyz'
+        },
+        request: {
+          colour: 'green'
+        }
+      });
+      done();
+    })
+
+    it("Should apply the latest request params, body or header specified", function(done) {
+      var Canned = require('../lib/canned')
+      var can = new Canned('./spec/test_responses', {});
+      var mock_text = '//! statusCode: 418\n' +
+                      '//! customHeaders: {"Authorization": "Bearer xyz"}\n' +
+                      '//! body: {"colour": "green"}\n' +
+                      '//! params: {"count": 126}';
+      var parsedMeta = can.parseMetaData(mock_text);
+
+      expect(parsedMeta).toEqual({
+        statusCode: 418,
+        customHeaders: {
+          Authorization: 'Bearer xyz'
+        },
+        request: {
+          count: '126',
+        }
+      });
+      done();
+    })
+  })
+
   describe("variable POST responses", function() {
     var req, data
     beforeEach(function() {


### PR DESCRIPTION
This change fixes a couple of problems:

The regexes as they stood were both matching per character, which makes for some interesting matches such as: http://rubular.com/r/uZpZRyhmpN

Changing the character group to a non-captured OR group makes the results:  http://rubular.com/r/XBXkjlu54P

It also removes the /g option from the regexp. Since the `.exec` method is called only once per line it was causing weird results because `/g` causes it to return falsy unexpectedly. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#Finding_successive_matches)

