### PR TITLE
remove windows line ending when reading file

### DIFF
--- a/lib/canned.js
+++ b/lib/canned.js
@@ -253,6 +253,7 @@ Canned.prototype._responseForFile = function (httpObj, files, cb) {
         response = new Response(getContentType('html'), '', 404, httpObj.res, that.response_opts)
         cb('Not found', response)
       } else {
+        data = data.replace(/\r/g, "");
         var _data = that.getVariableResponse(data, httpObj.content, httpObj.headers)
         data = _data.data
         var statusCode = _data.statusCode


### PR DESCRIPTION
When you have a response file with windows line endings, then when you try to request it, you get this error message
`
problem sanatizing content for _search.get.json SyntaxError: Unexpected token { served via: ./_search.get.json
`
This patch makes sure that when a file is read, all windows line endings are removed before any processing takes place,