### PR TITLE
adding PATCH to default Access-Control-Allow-Method Cors header

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ feel free to [bug me on twitter](https://twitter.com/ischi)
 Release History
 ---------------
 ### next
+* adding PATCH to default Access-Control-Allow-Method Cors header #113 (@william-mcmillian)
 
 ### 0.3.10
 * Windows line ending support #102 (@antxxxx)
@@ -436,6 +437,7 @@ Contributors
 * [CheungJ](https://github.com/CheungJ)
 * [antxxxx](https://github.com/antxxxx)
 * [mazoni](https://github.com/mazoni)
+* [william-mcmillian](https://github.com/william-mcmillian)
 
 License
 -------

--- a/lib/response.js
+++ b/lib/response.js
@@ -21,7 +21,7 @@ Response.content_types = {
 Response.cors_headers = [
   ['Access-Control-Allow-Origin', '*'],
   ['Access-Control-Allow-Headers', 'X-Requested-With'],
-  ['Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS']
+  ['Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS']
 ]
 
 Response.prototype.send = function () {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -374,7 +374,7 @@ describe('canned', function () {
       var expectedHeaders = {
         'Access-Control-Allow-Origin': "*",
         'Access-Control-Allow-Headers': "X-Requested-With",
-        'Access-Control-Allow-Methods': "GET, POST, PUT, DELETE, OPTIONS"
+        'Access-Control-Allow-Methods': "GET, POST, PUT, PATCH, DELETE, OPTIONS"
       }
       res.setHeader = function (name, value) {
         if (expectedHeaders[name]) {


### PR DESCRIPTION
Allowing PATCH by default in CORS headers to resolve failing cross-origin Patch requests