### PR TITLE
Fix 117 remove unsupported chars for windows install

### DIFF
--- a/lib/canned.js
+++ b/lib/canned.js
@@ -174,6 +174,7 @@ Canned.prototype.getSelectedResponse = function(responses, content, headers) {
   }
 
   stringifyValues(content);
+  // put the contents of the body and the headers into a big, indexed object.
   inputObj = cannedUtils.extend({}, content, headers)
 
   responses.forEach(function(response) {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -651,16 +651,6 @@ describe('canned', function () {
   })
 
   describe("Issues", function () {
-    it("#49", function (done) {
-      req.url = "/regexmatchbug?u=root&p=root&q=select+mean(value)+from+%22Coraid.1Controller.ZFS.VOps-3008.gauge.wlat%22+where+time+%3E++now()+-+86400000000u+and+time+%3C+now()+-+0u+group+by+time(240000000u)+fill(null)"
-      res.end = function (content) {
-        var response = JSON.parse(content)
-        expect(response.itworks).toBeTruthy()
-        done()
-      }
-      can(req, res)
-    })
-
     it("#58", function(done) {
       req.url = "/multiple_get_responses?" + querystring.stringify({foo: "apostrophe"})
       res.end = function(content) {

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -260,16 +260,7 @@ describe('canned', function () {
     })
 
     it('looks for _file with query params', function (done) {
-      req.url = '/a?name=Superman&age=30&idontneed=everyparaminfilename'
-      res.end = function (content) {
-        expect(content).toContain('Superman!')
-        done()
-      }
-      can(req, res)
-    })
-
-    it('looks for index file with query params', function (done) {
-      req.url = '/?name=Superman'
+      req.url = '/multimatch_query_param?name=Superman&age=30&idontneed=everyparaminfilename'
       res.end = function (content) {
         expect(content).toContain('Superman!')
         done()
@@ -278,7 +269,7 @@ describe('canned', function () {
     })
 
     it('can tell different query param files a part', function (done) {
-      req.url = '/a?name=Batman&age=30&idontneed=everyparaminfilename'
+      req.url = '/multimatch_query_param?name=Batman&age=30&idontneed=everyparaminfilename'
       res.end = function (content) {
         expect(content).toContain('Batman!')
         done()

--- a/spec/test_responses/_multimatch_query_param.get.html
+++ b/spec/test_responses/_multimatch_query_param.get.html
@@ -1,0 +1,5 @@
+//! params: {"name": "Batman", "age": "30"}
+Batman!
+
+//! params: {"name": "Superman", "age": "30"}
+Superman!

--- a/spec/test_responses/_regexmatchbug?u=root&p=root&q=select+from+%22Coraid-3008.gauge+time+%3E++now()+-+86400000000u+and+time+%3C+now().get.json
+++ b/spec/test_responses/_regexmatchbug?u=root&p=root&q=select+from+%22Coraid-3008.gauge+time+%3E++now()+-+86400000000u+and+time+%3C+now().get.json
@@ -1,3 +1,0 @@
-{
-    "itworks": true
-}

--- a/spec/test_responses/_regexmatchbug?u=root&p=root&q=select+from+%22Coraid-3008.gauge+time+%3E++now()+-+86400000000u+and+time+%3C+now().get.json
+++ b/spec/test_responses/_regexmatchbug?u=root&p=root&q=select+from+%22Coraid-3008.gauge+time+%3E++now()+-+86400000000u+and+time+%3C+now().get.json
@@ -1,0 +1,3 @@
+{
+    "itworks": true
+}

--- a/spec/test_responses/_regexmatchbug?u=root&p=root&q=select+mean(value)+from+%22Coraid.1Controller.ZFS.VOps-3008.gauge.wlat%22+where+time+%3E++now()+-+86400000000u+and+time+%3C+now()+-+0u+group+by+time(240000000u)+fill(null).get.json
+++ b/spec/test_responses/_regexmatchbug?u=root&p=root&q=select+mean(value)+from+%22Coraid.1Controller.ZFS.VOps-3008.gauge.wlat%22+where+time+%3E++now()+-+86400000000u+and+time+%3C+now()+-+0u+group+by+time(240000000u)+fill(null).get.json
@@ -1,3 +1,0 @@
-{
-  "itworks": true
-}

--- a/spec/test_responses/index?name=Superman.get.html
+++ b/spec/test_responses/index?name=Superman.get.html
@@ -1,1 +1,0 @@
-Superman!


### PR DESCRIPTION
Based on #119 this should fix #117 by removing all the unsupported char file names from the test dir.